### PR TITLE
(SIMP-3030) Add defines to generate JS rules

### DIFF
--- a/.puppet-lint.rc
+++ b/.puppet-lint.rc
@@ -2,5 +2,8 @@
 --relative
 --no-class_inherits_from_params_class-check
 --no-140chars-check
+--no-empty_string-check
 --no-trailing_comma-check
---no-empty_string_assignment-check
+# This is here because the code can't handle lookups in parameters and we have
+# a LOT of those
+--no-parameter_order-check

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,13 @@
-#  PE/SIMP versions
-#  app    pup  ruby
-# 2015.2  4.3  2.1.7
-# 2015.3  4.3  2.1.8
-# 2016.1  4.4  2.1.9
-# 2016.2  4.5  2.1.9
-# S6.0.0  4.7  2.1.9
+# The testing matrix considers ruby/puppet versions supported by SIMP and PE:
+# ------------------------------------------------------------------------------
+#  release    pup   ruby      eol
+# PE 2015.2   4.2   2.1.7  2017-03-17
+# PE 2015.3   4.3   2.1.8  2017-03-17
+# PE 2016.1   4.4   2.1.9  2017-03-17 (yes: all three EOL on the same day!)
+# PE 2016.2   4.5   2.1.9  2017-04-30
+# PE 2016.4   4.7   2.1.9  TBD (LTS)
+# PE 2016.5   4.8   2.1.9  TBD
+# SIMP6.0.0   4.8   2.1.9  TBD
 ---
 language: ruby
 sudo: false
@@ -24,17 +27,19 @@ env:
     - STRICT_VARIABLES=yes
     - TRUSTED_NODE_DATA=yes
   matrix:
+    - PUPPET_VERSION="~> 4.9.4"
+    - PUPPET_VERSION="~> 4.8.2"
     - PUPPET_VERSION="~> 4.7.0"
     - PUPPET_VERSION="~> 4.5.0"
-    - PUPPET_VERSION="~> 3.8.0"
     - PUPPET_VERSION="~> 4.4.0"
     - PUPPET_VERSION="~> 4.3.0"
-    - PUPPET_VERSION="~> 3.8.0" FUTURE_PARSER=yes
+    - PUPPET_VERSION="~> 4.2.0"
 matrix:
   fast_finish: true
   allow_failures:
+    - env: PUPPET_VERSION="~> 4.9.4"
+    - env: PUPPET_VERSION="~> 4.7.0"
     - env: PUPPET_VERSION="~> 4.5.0"
-    - env: PUPPET_VERSION="~> 3.8.0"
     - env: PUPPET_VERSION="~> 4.4.0"
     - env: PUPPET_VERSION="~> 4.3.0"
-    - env: PUPPET_VERSION="~> 3.8.0" FUTURE_PARSER=yes
+    - env: PUPPET_VERSION="~> 4.2.0"

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+* Mon Apr 17 2017 Nick Miller <nick.miller@onyxpoint.com> - 6.1.0-0
+- Add EL7 and polkit 106+ support by allowing javascript rules
+  - Added define to allow for easy placement of custom rules
+  - Added templated define to ease generation of basic rules
+
 * Mon Dec 19 2016 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - 6.0.0-0
 - Strong Typing
 - Code cleanup

--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ group :test do
   gem 'hiera-puppet-helper'
   gem 'puppetlabs_spec_helper'
   gem 'metadata-json-lint'
+  gem 'puppet-strings'
   gem 'puppet-lint-empty_string-check',   :require => false
   gem 'puppet-lint-trailing_comma-check', :require => false
   gem 'simp-rspec-puppet-facts', ENV.fetch('SIMP_RSPEC_PUPPET_FACTS_VERSION', '~> 1.3')
@@ -24,7 +25,6 @@ group :development do
   gem 'travis-lint'
   gem 'travish'
   gem 'puppet-blacksmith'
-  gem 'puppet-strings'
   gem 'guard-rake'
   gem 'pry'
   gem 'pry-doc'

--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,4 @@
 require 'simp/rake/pupmod/helpers'
+require 'puppet-strings/tasks'
 
 Simp::Rake::Pupmod::Helpers.new(File.dirname(__FILE__))
-

--- a/lib/puppet/functions/polkit/condition.rb
+++ b/lib/puppet/functions/polkit/condition.rb
@@ -1,0 +1,24 @@
+# Generate a condition for a policykit rule
+Puppet::Functions.create_function(:'polkit::condition') do
+  dispatch :condition do
+    param 'String', :action_id
+    param "Struct[{
+      Optional[group]  => Optional[String],
+      Optional[user]   => Optional[String],
+      Optional[local]  => Boolean,
+      Optional[active] => Boolean,
+    }]", :opts
+
+    return_type 'String'
+  end
+
+  def condition(action_id, opts)
+    cond = []
+    cond << "(action.id == '#{action_id}')"
+    cond << "subject.user == '#{opts['user']}'"     if opts['user']
+    cond << "subject.isInGroup('#{opts['group']}')" if opts['group']
+    cond << 'subject.local'                         if opts['local']
+    cond << 'subject.active'                        if opts['active']
+    cond.join(' && ')
+  end
+end

--- a/lib/puppet/functions/polkit/condition.rb
+++ b/lib/puppet/functions/polkit/condition.rb
@@ -3,8 +3,8 @@ Puppet::Functions.create_function(:'polkit::condition') do
   dispatch :condition do
     param 'String', :action_id
     param "Struct[{
-      Optional[group]  => Optional[String],
-      Optional[user]   => Optional[String],
+      Optional[group]  => Optional[Variant[String,Array[String]]],
+      Optional[user]   => Optional[Variant[String,Array[String]]],
       Optional[local]  => Boolean,
       Optional[active] => Boolean,
     }]", :opts
@@ -15,10 +15,21 @@ Puppet::Functions.create_function(:'polkit::condition') do
   def condition(action_id, opts)
     cond = []
     cond << "(action.id == '#{action_id}')"
-    cond << "subject.user == '#{opts['user']}'"     if opts['user']
-    cond << "subject.isInGroup('#{opts['group']}')" if opts['group']
     cond << 'subject.local'                         if opts['local']
     cond << 'subject.active'                        if opts['active']
+
+    if opts['user'].is_a?(Array)
+      opts['user'].each { |u| cond << "subject.user == '#{u}'" }
+    else
+      cond << "subject.user == '#{opts['user']}'" if opts['user']
+    end
+
+    if opts['group'].is_a?(Array)
+      opts['group'].each { |g| cond << "subject.isInGroup('#{g}')" }
+    else
+      cond << "subject.isInGroup('#{opts['group']}')" if opts['group']
+    end
+
     cond.join(' && ')
   end
 end

--- a/manifests/authorization/basic_policy.pp
+++ b/manifests/authorization/basic_policy.pp
@@ -65,18 +65,18 @@
 # @param rulesd Location of the poklit rules directory
 #
 define polkit::authorization::basic_policy (
-  Enum['present','absent'] $ensure,
-  Polkit::Result           $result,
-  Optional[String]         $action_id   = undef,
-  Optional[String]         $group       = undef,
-  Optional[String]         $user        = undef,
-  Boolean                  $local       = false,
-  Boolean                  $active      = false,
-  Optional[String]         $condition   = undef,
-  Boolean                  $log_action  = true,
-  Boolean                  $log_subject = true,
-  Integer[0,99]            $priority    = 10,
-  Stdlib::AbsolutePath     $rulesd      = '/etc/polkit-1/rules.d',
+  Enum['present','absent']            $ensure,
+  Polkit::Result                      $result,
+  Optional[String]                    $action_id   = undef,
+  Variant[Undef,String,Array[String]] $group       = undef,
+  Variant[Undef,String,Array[String]] $user        = undef,
+  Boolean                             $local       = false,
+  Boolean                             $active      = false,
+  Optional[String]                    $condition   = undef,
+  Boolean                             $log_action  = true,
+  Boolean                             $log_subject = true,
+  Integer[0,99]                       $priority    = 10,
+  Stdlib::AbsolutePath                $rulesd      = '/etc/polkit-1/rules.d',
 ) {
   if !$condition {
     if !$action_id {

--- a/manifests/authorization/basic_policy.pp
+++ b/manifests/authorization/basic_policy.pp
@@ -41,17 +41,18 @@
 #
 # @param ensure Create or destroy the rules file
 #
-# @param result The end result of the polkit, like 'yes' or 'auth_admin'
+# @param result The authorization result of the polkit transaction, for
+#   example 'yes' or 'auth_admin'
 #
 # @param action_id The polkit action to operate on
 #
 #   * A list of available actions can be found by running `pkaction`
 #
-# @param group Group to check membership of
-#
 # @param user User to check
 #
-# @param local Check of the user is a local user. See man page for more
+# @param group The group(s) that the user checking authorization belongs to
+#
+# @param local Check if the user is a local user. See man page for more
 #   explaination.
 #
 # @param active Check if the user is currently active. See man page for more
@@ -68,8 +69,8 @@ define polkit::authorization::basic_policy (
   Enum['present','absent']            $ensure,
   Polkit::Result                      $result,
   Optional[String]                    $action_id   = undef,
-  Variant[Undef,String,Array[String]] $group       = undef,
   Variant[Undef,String,Array[String]] $user        = undef,
+  Variant[Undef,String,Array[String]] $group       = undef,
   Boolean                             $local       = false,
   Boolean                             $active      = false,
   Optional[String]                    $condition   = undef,

--- a/manifests/authorization/basic_policy.pp
+++ b/manifests/authorization/basic_policy.pp
@@ -102,8 +102,12 @@ define polkit::authorization::basic_policy (
   // This file is managed by Puppet
   polkit.addRule(function(action, subject) {
     if (<%= $_condition -%>) {
-        <% if $log_action  { -%> polkit.log("action=" + action); <% } %>
-        <% if $log_subject { -%> polkit.log("subject=" + subject); <% } %>
+        <%- if $log_action  { -%>
+        polkit.log("action=" + action);
+        <%- } -%>
+        <%- if $log_subject { -%>
+        polkit.log("subject=" + subject);
+        <%- } -%>
         return polkit.Result.<%= $result.upcase -%>;
       }
     }

--- a/manifests/authorization/basic_policy.pp
+++ b/manifests/authorization/basic_policy.pp
@@ -1,0 +1,116 @@
+# Add a rule file containing javascript Polkit configuration to the system
+#
+# @see polkit(8)
+#
+# The intention of this define is to make it easy to add simple polkit rules
+# to a system. An example simple rule template is shown below:
+#
+# ```
+# // This file is managed by Puppet
+# polkit.addRule(function(action, subject) {
+#   if (<condition>) {
+#       return polkit.Result.<result>;
+#     }
+#   }
+# });
+# ```
+#
+# A user-specified <condition> can be supplied with the $condition parameter,
+# or the define can use the polkit::condition function to generate a condition
+# using $action_id, $user and/or $group, an (optionally) $local and $active.
+#
+# @example Allow users in the virtusers group to use the system libvirt
+#   polkit::authorization::basic_policy { 'Allow users to use libvirt':
+#     ensure    => present,
+#     group     => 'virtusers',
+#     result    => ''
+#     action_id => 'org.libvirt.unix.manage',
+#     priority  => 20,
+#     local     => true,
+#     active    => true,
+#   }
+#
+#   # Generates a policy file that looks like this
+#   // This file is managed by Puppet
+#   polkit.addRule(function(action, subject) {
+#     if ((action.id == 'org.libvirt.unix.manage') && subject.user == 'testuser' && subject.isInGroup('testgroup') && subject.local && subject.active) {
+#         return polkit.Result.YES;
+#       }
+#     }
+#   });
+#
+# @param ensure Create or destroy the rules file
+#
+# @param result The end result of the polkit, like 'yes' or 'auth_admin'
+#
+# @param action_id The polkit action to operate on
+#
+#   * A list of available actions can be found by running `pkaction`
+#
+# @param group Group to check membership of
+#
+# @param user User to check
+#
+# @param local Check of the user is a local user. See man page for more
+#   explaination.
+#
+# @param active Check if the user is currently active. See man page for more
+#   explaination.
+#
+# @param condition If specified, will be placed in the javascript condition to be met
+#   for polkit authorization
+#
+# @param priority Priority of the file to be created
+#
+# @param rulesd Location of the poklit rules directory
+#
+define polkit::authorization::basic_policy (
+  Enum['present','absent'] $ensure,
+  Polkit::Result           $result,
+  Optional[String]         $action_id = undef,
+  Optional[String]         $group     = undef,
+  Optional[String]         $user      = undef,
+  Boolean                  $local     = false,
+  Boolean                  $active    = false,
+  Optional[String]         $condition = undef,
+  Integer[0,99]            $priority  = 10,
+  Stdlib::AbsolutePath     $rulesd    = '/etc/polkit-1/rules.d',
+) {
+  if !$condition {
+    if !$action_id {
+      fail('If $condition is not specified, $action_id must be')
+    }
+  }
+  if $facts['os']['release']['major'] == '6' {
+    fail('The version of Polkit available on EL6 does not support javascript configuration')
+  }
+
+  $_opts = {
+    'group'  => $group,
+    'user'   => $user,
+    'local'  => $local,
+    'active' => $active,
+  }
+  $_condition = $condition ? {
+    String  => $condition,
+    default => polkit::condition($action_id, $_opts)
+  }
+
+  $_content = @("EOF")
+  // This file is managed by Puppet
+  polkit.addRule(function(action, subject) {
+    if (${_condition}) {
+        return polkit.Result.${result.upcase};
+      }
+    }
+  });
+  |EOF
+
+  polkit::authorization::rule { $name:
+    ensure   => $ensure,
+    priority => $priority,
+    rulesd   => $rulesd,
+    content  => $_content,
+  }
+
+}

--- a/manifests/authorization/rule.pp
+++ b/manifests/authorization/rule.pp
@@ -1,0 +1,29 @@
+# Add a rule file containing javascript Polkit configuration to the system
+#
+# @param ensure Create or destroy the rules file
+#
+# @param content An arbitrary string of javascript polkit configuration
+#
+# @param priority Priority of the file to be created, lower priority means
+#   the rule would be read earlier
+#
+# @param rulesd Location of the poklit rules directory
+#
+define polkit::authorization::rule (
+  Enum['present','absent'] $ensure,
+  Optional[String]         $content,
+  Integer[0,99]            $priority = 10,
+  Stdlib::AbsolutePath     $rulesd   = '/etc/polkit-1/rules.d'
+) {
+
+  $_name = regsubst($name,'\/','_')
+
+  file { "${rulesd}/${priority}-${_name}.rules":
+    ensure  => $ensure,
+    content => $content,
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0644',
+  }
+
+}

--- a/manifests/authorization/rule.pp
+++ b/manifests/authorization/rule.pp
@@ -16,7 +16,7 @@ define polkit::authorization::rule (
   Stdlib::AbsolutePath     $rulesd   = '/etc/polkit-1/rules.d'
 ) {
 
-  $_name = regsubst($name,'\/','_')
+  $_name = regsubst($name.downcase, '( |/)', '_', 'G')
 
   file { "${rulesd}/${priority}-${_name}.rules":
     ensure  => $ensure,

--- a/manifests/authorization/rule.pp
+++ b/manifests/authorization/rule.pp
@@ -16,7 +16,8 @@ define polkit::authorization::rule (
   Stdlib::AbsolutePath     $rulesd   = '/etc/polkit-1/rules.d'
 ) {
 
-  $_name = regsubst($name.downcase, '( |/)', '_', 'G')
+  $_name = regsubst($name.downcase, '( |/|!|@|#|\$|%|\^|&|\*|[|])', '_', 'G')
+  inspect($_name)
 
   file { "${rulesd}/${priority}-${_name}.rules":
     ensure  => $ensure,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -11,7 +11,5 @@
 class polkit (
   Polkit::PackageEnsure $package_ensure = simplib::lookup('simp_options::package_ensure', { 'default_value' => 'installed' })
 ) {
-  package { 'polkit':
-    ensure => $package_ensure,
-  }
+  package { 'polkit': ensure => $package_ensure }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-polkit",
-  "version": "6.0.0",
+  "version": "6.1.0",
   "author": "SIMP Team",
   "summary": "Manages PolicyKit objects",
   "license": "Apache-2.0",

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -7,9 +7,11 @@ describe 'polkit' do
         facts
       end
 
-      it { is_expected.to compile.with_all_deps }
-      it { is_expected.to create_class('polkit') }
-      it { is_expected.to contain_package('polkit').with_ensure('installed') }
+      context 'with default parameters' do
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to create_class('polkit') }
+        it { is_expected.to contain_package('polkit').with_ensure('installed') }
+      end
 
     end
   end

--- a/spec/defines/authorization/basic_policy_spec.rb
+++ b/spec/defines/authorization/basic_policy_spec.rb
@@ -70,7 +70,7 @@ polkit.addRule(function(action, subject) {
 // This file is managed by Puppet
 polkit.addRule(function(action, subject) {
   if (some whacky javascript hack) {
-      polkit.log("action=" + action); 
+      polkit.log("action=" + action);
       polkit.log("subject=" + subject);
       return polkit.Result.AUTH_ADMIN;
     }
@@ -80,6 +80,28 @@ polkit.addRule(function(action, subject) {
         }) }
       end
 
+      context 'without logging' do
+        let(:title) { 'test' }
+        let(:params) {{
+          :ensure      => 'present',
+          :result      => 'auth_admin',
+          :condition   => 'some whacky javascript hack',
+          :log_action  => false,
+          :log_subject => false
+        }}
+        it { is_expected.to create_polkit__authorization__rule('test').with({
+          :ensure => 'present',
+          :content => <<-EOF
+// This file is managed by Puppet
+polkit.addRule(function(action, subject) {
+  if (some whacky javascript hack) {
+      return polkit.Result.AUTH_ADMIN;
+    }
+  }
+});
+          EOF
+        }) }
+      end
 
     end
   end

--- a/spec/defines/authorization/basic_policy_spec.rb
+++ b/spec/defines/authorization/basic_policy_spec.rb
@@ -23,6 +23,8 @@ describe 'polkit::authorization::basic_policy' do
 // This file is managed by Puppet
 polkit.addRule(function(action, subject) {
   if ((action.id == 'an.action') && subject.isInGroup('developers')) {
+      polkit.log("action=" + action);
+      polkit.log("subject=" + subject);
       return polkit.Result.YES;
     }
   }
@@ -45,6 +47,8 @@ polkit.addRule(function(action, subject) {
 // This file is managed by Puppet
 polkit.addRule(function(action, subject) {
   if ((action.id == 'an.action') && subject.user == 'person') {
+      polkit.log("action=" + action);
+      polkit.log("subject=" + subject);
       return polkit.Result.NO;
     }
   }
@@ -66,6 +70,8 @@ polkit.addRule(function(action, subject) {
 // This file is managed by Puppet
 polkit.addRule(function(action, subject) {
   if (some whacky javascript hack) {
+      polkit.log("action=" + action); 
+      polkit.log("subject=" + subject);
       return polkit.Result.AUTH_ADMIN;
     }
   }

--- a/spec/defines/authorization/basic_policy_spec.rb
+++ b/spec/defines/authorization/basic_policy_spec.rb
@@ -33,6 +33,30 @@ polkit.addRule(function(action, subject) {
         }) }
       end
 
+      context 'authorize list of groups to do an action' do
+        let(:title) { 'test' }
+        let(:params) {{
+          :ensure    => 'present',
+          :result    => 'yes',
+          :action_id => 'an.action',
+          :group     => ['developers0','developers1','developers2'],
+        }}
+        it { is_expected.to create_polkit__authorization__rule('test').with({
+          :ensure => 'present',
+          :content => <<-EOF
+// This file is managed by Puppet
+polkit.addRule(function(action, subject) {
+  if ((action.id == 'an.action') && subject.isInGroup('developers0') && subject.isInGroup('developers1') && subject.isInGroup('developers2')) {
+      polkit.log("action=" + action);
+      polkit.log("subject=" + subject);
+      return polkit.Result.YES;
+    }
+  }
+});
+          EOF
+        }) }
+      end
+
       context 'deny a user to do an action' do
         let(:title) { 'test' }
         let(:params) {{

--- a/spec/defines/authorization/basic_policy_spec.rb
+++ b/spec/defines/authorization/basic_policy_spec.rb
@@ -1,0 +1,80 @@
+require 'spec_helper'
+
+describe 'polkit::authorization::basic_policy' do
+  supported_os = on_supported_os.delete_if { |e| e =~ /-6-/ } #TODO do this right
+  supported_os.each do |os, facts|
+  # on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      let(:facts) do
+        facts
+      end
+
+      context 'authorize group to do an action' do
+        let(:title) { 'test' }
+        let(:params) {{
+          :ensure    => 'present',
+          :result    => 'yes',
+          :action_id => 'an.action',
+          :group     => 'developers',
+        }}
+        it { is_expected.to create_polkit__authorization__rule('test').with({
+          :ensure => 'present',
+          :content => <<-EOF
+// This file is managed by Puppet
+polkit.addRule(function(action, subject) {
+  if ((action.id == 'an.action') && subject.isInGroup('developers')) {
+      return polkit.Result.YES;
+    }
+  }
+});
+          EOF
+        }) }
+      end
+
+      context 'deny a user to do an action' do
+        let(:title) { 'test' }
+        let(:params) {{
+          :ensure    => 'present',
+          :result    => 'no',
+          :action_id => 'an.action',
+          :user      => 'person',
+        }}
+        it { is_expected.to create_polkit__authorization__rule('test').with({
+          :ensure => 'present',
+          :content => <<-EOF
+// This file is managed by Puppet
+polkit.addRule(function(action, subject) {
+  if ((action.id == 'an.action') && subject.user == 'person') {
+      return polkit.Result.NO;
+    }
+  }
+});
+          EOF
+        }) }
+      end
+
+      context 'with a custom conditional set' do
+        let(:title) { 'test' }
+        let(:params) {{
+          :ensure    => 'present',
+          :result    => 'auth_admin',
+          :condition => 'some whacky javascript hack'
+        }}
+        it { is_expected.to create_polkit__authorization__rule('test').with({
+          :ensure => 'present',
+          :content => <<-EOF
+// This file is managed by Puppet
+polkit.addRule(function(action, subject) {
+  if (some whacky javascript hack) {
+      return polkit.Result.AUTH_ADMIN;
+    }
+  }
+});
+          EOF
+        }) }
+      end
+
+
+    end
+  end
+end

--- a/spec/defines/authorization/rule_spec.rb
+++ b/spec/defines/authorization/rule_spec.rb
@@ -1,0 +1,41 @@
+require 'spec_helper'
+
+describe 'polkit::authorization::rule' do
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      let(:facts) do
+        facts
+      end
+
+      context 'with minimal parameters' do
+        let(:title) {'test'}
+        let(:params) {{
+          :ensure  => 'present',
+          :content => 'totally javascript trust me it me your friend'
+        }}
+        it { is_expected.to create_file('/etc/polkit-1/rules.d/10-test.rules') }
+      end
+
+      context 'with a name that requires substitution' do
+        let(:title) {'libvirt/users'}
+        let(:params) {{
+          :ensure  => 'present',
+          :content => 'totally javascript trust me it me your friend'
+        }}
+        it { is_expected.to create_file('/etc/polkit-1/rules.d/10-libvirt_users.rules') }
+      end
+
+      context 'with a different priority and rulesd' do
+        let(:title) {'test'}
+        let(:params) {{
+          :ensure   => 'present',
+          :content  => 'totally javascript trust me it me your friend',
+          :priority => 99,
+          :rulesd   => '/best/path'
+        }}
+        it { is_expected.to create_file('/best/path/99-test.rules') }
+      end
+
+    end
+  end
+end

--- a/spec/defines/authorization/rule_spec.rb
+++ b/spec/defines/authorization/rule_spec.rb
@@ -17,12 +17,12 @@ describe 'polkit::authorization::rule' do
       end
 
       context 'with a name that requires substitution' do
-        let(:title) {'libvirt/users'}
+        let(:title) {'A rule that manages libvirt/users'}
         let(:params) {{
           :ensure  => 'present',
           :content => 'totally javascript trust me it me your friend'
         }}
-        it { is_expected.to create_file('/etc/polkit-1/rules.d/10-libvirt_users.rules') }
+        it { is_expected.to create_file('/etc/polkit-1/rules.d/10-a_rule_that_manages_libvirt_users.rules') }
       end
 
       context 'with a different priority and rulesd' do

--- a/spec/functions/polkit/condition_spec.rb
+++ b/spec/functions/polkit/condition_spec.rb
@@ -18,9 +18,21 @@ describe 'polkit::condition' do
   }
 
   it { is_expected.to run.with_params(
+      'org.libvirt.unix.manage',
+      { 'group' => ['virshusers0','virshusers1','virshusers2'] }
+    ).and_return("(action.id == 'org.libvirt.unix.manage') && subject.isInGroup('virshusers0') && subject.isInGroup('virshusers1') && subject.isInGroup('virshusers2')")
+  }
+
+  it { is_expected.to run.with_params(
     'org.libvirt.unix.manage',
     { 'user' => 'testuser' }
     ).and_return("(action.id == 'org.libvirt.unix.manage') && subject.user == 'testuser'")
+  }
+
+  it { is_expected.to run.with_params(
+    'org.libvirt.unix.manage',
+    { 'user' => ['testuser0','testuser1','testuser2'] }
+    ).and_return("(action.id == 'org.libvirt.unix.manage') && subject.user == 'testuser0' && subject.user == 'testuser1' && subject.user == 'testuser2'")
   }
 
   it { is_expected.to run.with_params(
@@ -31,26 +43,32 @@ describe 'polkit::condition' do
 
   it { is_expected.to run.with_params(
     'org.libvirt.unix.manage',
+    { 'user' => ['testuser0','testuser1'], 'group' => ['virshusers0','virshusers1'] }
+    ).and_return("(action.id == 'org.libvirt.unix.manage') && subject.user == 'testuser0' && subject.user == 'testuser1' && subject.isInGroup('virshusers0') && subject.isInGroup('virshusers1')")
+  }
+
+  it { is_expected.to run.with_params(
+    'org.libvirt.unix.manage',
     { 'user' => 'testuser', 'local' => true }
-    ).and_return("(action.id == 'org.libvirt.unix.manage') && subject.user == 'testuser' && subject.local")
+    ).and_return("(action.id == 'org.libvirt.unix.manage') && subject.local && subject.user == 'testuser'")
   }
 
   it { is_expected.to run.with_params(
     'org.libvirt.unix.manage',
     { 'user' => 'testuser', 'active' => true }
-    ).and_return("(action.id == 'org.libvirt.unix.manage') && subject.user == 'testuser' && subject.active")
+    ).and_return("(action.id == 'org.libvirt.unix.manage') && subject.active && subject.user == 'testuser'")
   }
 
   it { is_expected.to run.with_params(
     'org.libvirt.unix.manage',
     { 'user' => 'testuser', 'active' => true, 'local' => true }
-    ).and_return("(action.id == 'org.libvirt.unix.manage') && subject.user == 'testuser' && subject.local && subject.active")
+    ).and_return("(action.id == 'org.libvirt.unix.manage') && subject.local && subject.active && subject.user == 'testuser'")
   }
 
   it { is_expected.to run.with_params(
     'org.libvirt.unix.manage',
     { 'user' => 'testuser', 'active' => true, 'local' => true, 'group' => 'testgroup' }
-    ).and_return("(action.id == 'org.libvirt.unix.manage') && subject.user == 'testuser' && subject.isInGroup('testgroup') && subject.local && subject.active")
+    ).and_return("(action.id == 'org.libvirt.unix.manage') && subject.local && subject.active && subject.user == 'testuser' && subject.isInGroup('testgroup')")
   }
 
 end

--- a/spec/functions/polkit/condition_spec.rb
+++ b/spec/functions/polkit/condition_spec.rb
@@ -1,0 +1,56 @@
+require 'spec_helper'
+
+describe 'polkit::condition' do
+
+  it { is_expected.to run.with_params().and_raise_error(/expects 2 arguments, got none/i) }
+  it { is_expected.to run.with_params('org.libvirt.unix.manage').and_raise_error(/expects 2 arguments, got 1/i) }
+
+  it { is_expected.to run.with_params(
+    'org.libvirt.unix.manage',
+    { 'notaparam' => 'break' }
+    ).and_raise_error(/unrecognized key 'notaparam'/i)
+  }
+
+  it { is_expected.to run.with_params(
+      'org.libvirt.unix.manage',
+      { 'group' => 'virshusers' }
+    ).and_return("(action.id == 'org.libvirt.unix.manage') && subject.isInGroup('virshusers')")
+  }
+
+  it { is_expected.to run.with_params(
+    'org.libvirt.unix.manage',
+    { 'user' => 'testuser' }
+    ).and_return("(action.id == 'org.libvirt.unix.manage') && subject.user == 'testuser'")
+  }
+
+  it { is_expected.to run.with_params(
+    'org.libvirt.unix.manage',
+    { 'user' => 'testuser', 'group' => 'virshusers' }
+    ).and_return("(action.id == 'org.libvirt.unix.manage') && subject.user == 'testuser' && subject.isInGroup('virshusers')")
+  }
+
+  it { is_expected.to run.with_params(
+    'org.libvirt.unix.manage',
+    { 'user' => 'testuser', 'local' => true }
+    ).and_return("(action.id == 'org.libvirt.unix.manage') && subject.user == 'testuser' && subject.local")
+  }
+
+  it { is_expected.to run.with_params(
+    'org.libvirt.unix.manage',
+    { 'user' => 'testuser', 'active' => true }
+    ).and_return("(action.id == 'org.libvirt.unix.manage') && subject.user == 'testuser' && subject.active")
+  }
+
+  it { is_expected.to run.with_params(
+    'org.libvirt.unix.manage',
+    { 'user' => 'testuser', 'active' => true, 'local' => true }
+    ).and_return("(action.id == 'org.libvirt.unix.manage') && subject.user == 'testuser' && subject.local && subject.active")
+  }
+
+  it { is_expected.to run.with_params(
+    'org.libvirt.unix.manage',
+    { 'user' => 'testuser', 'active' => true, 'local' => true, 'group' => 'testgroup' }
+    ).and_return("(action.id == 'org.libvirt.unix.manage') && subject.user == 'testuser' && subject.isInGroup('testgroup') && subject.local && subject.active")
+  }
+
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -84,7 +84,7 @@ RSpec.configure do |c|
     :production => {
       #:fqdn           => 'production.rspec.test.localdomain',
       :path           => '/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin',
-      :concat_basedir => '/tmp'
+      :concat_basedir => '/tmp',
     }
   }
 

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -28,11 +28,7 @@ RSpec.configure do |c|
     begin
       # Install modules and dependencies from spec/fixtures/modules
       copy_fixture_modules_to( hosts )
-      begin
-        server = only_host_with_role(hosts, 'server')
-      rescue ArgumentError =>e
-        server = only_host_with_role(hosts, 'default')
-      end
+      server = only_host_with_role(hosts, 'server')
 
       # Generate and install PKI certificates on each SUT
       Dir.mktmpdir do |cert_dir|

--- a/templates/basic_policy.epp
+++ b/templates/basic_policy.epp
@@ -1,0 +1,19 @@
+<%- |
+  String  $_condition,
+  Boolean $log_action,
+  Boolean $log_subject,
+  String  $result
+| -%>
+// This file is managed by Puppet
+polkit.addRule(function(action, subject) {
+  if (<%= $_condition -%>) {
+      <%- if $log_action  { -%>
+      polkit.log("action=" + action);
+      <%- } -%>
+      <%- if $log_subject { -%>
+      polkit.log("subject=" + subject);
+      <%- } -%>
+      return polkit.Result.<%= $result.upcase -%>;
+    }
+  }
+});


### PR DESCRIPTION
This commit adds a define for creating javascript polkit rules to be put
in `/etc/polkit-1/rules.d/`. It also adds a define for adding a
templated rule, with one basic condition and one basic response.

SIMP-3030 #close