### PR TITLE
(SIMP-8228) EL6 backwards compatibility workaround

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,8 @@
 - Ensure that the polkit user is managed by default and placed into the
   supplementary group bound to the 'gid' option on '/proc' if one is set to work
   around issues with 'hidepid' > 0.
+- Made the entire main class inert on unsupported OSs and log a warning on the
+  server that can be disabled
 
 * Tue Dec 24 2019 Trevor Vaughan <tvaughan@onyxpoint.com> - 6.2.0-0
 - Add EL8 support

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -63,6 +63,17 @@ The ensure status of packages
 
 Default value: `simplib::lookup('simp_options::package_ensure', { 'default_value' => 'installed' })`
 
+##### `warn_on_unsupported_os`
+
+Data type: `Boolean`
+
+Warn if the module is trying to be used on an unsupported OS
+
+* The module will not fail on an unsupported OS but also will not perform
+  any action
+
+Default value: ``true``
+
 ### `polkit::install`
 
 Manage the polkit package

--- a/manifests/authorization/basic_policy.pp
+++ b/manifests/authorization/basic_policy.pp
@@ -90,20 +90,21 @@ define polkit::authorization::basic_policy (
   Integer[0,99]                       $priority    = 10,
   Stdlib::AbsolutePath                $rulesd      = '/etc/polkit-1/rules.d',
 ) {
-  simplib::assert_metadata($module_name)
+  # For backwards compatibility purposes, this defined type is inert if called from an unsupported OS
+  if simplib::module_metadata::os_supported( load_module_metadata($module_name), { 'release_match' => 'major' }) {
+    include polkit
 
-  include polkit
-
-  if !$condition {
-    if !$action_id {
-      fail('If $condition is not specified, $action_id must be')
+    if !$condition {
+      if !$action_id {
+        fail('If $condition is not specified, $action_id must be')
+      }
     }
-  }
 
-  polkit::authorization::rule { $name:
-    ensure   => $ensure,
-    priority => $priority,
-    rulesd   => $rulesd,
-    content  => template('polkit/basic_policy.erb'),
+    polkit::authorization::rule { $name:
+      ensure   => $ensure,
+      priority => $priority,
+      rulesd   => $rulesd,
+      content  => template('polkit/basic_policy.erb'),
+    }
   }
 }

--- a/manifests/authorization/rule.pp
+++ b/manifests/authorization/rule.pp
@@ -18,17 +18,18 @@ define polkit::authorization::rule (
   Integer[0,99]            $priority = 10,
   Stdlib::AbsolutePath     $rulesd   = '/etc/polkit-1/rules.d'
 ) {
-  simplib::assert_metadata($module_name)
+  # For backwards compatibility purposes, this defined type is inert if called from an unsupported OS
+  if simplib::module_metadata::os_supported( load_module_metadata($module_name), { 'release_match' => 'major' }) {
+    include polkit
 
-  include polkit
+    $_name = regsubst($name.downcase, '( |/|!|@|#|\$|%|\^|&|\*|[|])', '_', 'G')
 
-  $_name = regsubst($name.downcase, '( |/|!|@|#|\$|%|\^|&|\*|[|])', '_', 'G')
-
-  file { "${rulesd}/${priority}-${_name}.rules":
-    ensure  => $ensure,
-    content => $content,
-    owner   => 'root',
-    group   => 'root',
-    mode    => '0644',
+    file { "${rulesd}/${priority}-${_name}.rules":
+      ensure  => $ensure,
+      content => $content,
+      owner   => 'root',
+      group   => 'root',
+      mode    => '0644',
+    }
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -15,23 +15,33 @@
 # @param package_ensure
 #   The ensure status of packages
 #
+# @param warn_on_unsupported_os
+#   Warn if the module is trying to be used on an unsupported OS
+#
+#   * The module will not fail on an unsupported OS but also will not perform
+#     any action
+#
 # @author https://github.com/simp/pupmod-simp-polkit/graphs/contributors
 #
 class polkit (
-  Boolean               $manage_polkit_user = true,
-  Polkit::PackageEnsure $package_ensure     = simplib::lookup('simp_options::package_ensure', { 'default_value' => 'installed' })
+  Boolean               $manage_polkit_user     = true,
+  Polkit::PackageEnsure $package_ensure         = simplib::lookup('simp_options::package_ensure', { 'default_value' => 'installed' }),
+  Boolean               $warn_on_unsupported_os = true
 ){
-  simplib::assert_metadata($module_name)
+  if simplib::module_metadata::os_supported( load_module_metadata($module_name), { 'release_match' => 'major' }) {
+    include polkit::install
+    include polkit::service
 
-  include polkit::install
-  include polkit::service
+    Class['polkit::install'] ~> Class['polkit::service']
 
-  Class['polkit::install'] ~> Class['polkit::service']
+    if $manage_polkit_user {
+      include polkit::user
 
-  if $manage_polkit_user {
-    include polkit::user
-
-    Class['polkit::install'] -> Class['polkit::user']
-    Class['polkit::user'] ~> Class['polkit::service']
+      Class['polkit::install'] -> Class['polkit::user']
+      Class['polkit::user'] ~> Class['polkit::service']
+    }
+  }
+  elsif $warn_on_unsupported_os {
+    warning("${facts['os']['name']} ${facts['os']['release']['full']} is not supported by ${module_name}. To silence this warning, set ${module_name}::warn_on_unsupported_os to 'false'")
   }
 }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -20,4 +20,23 @@ describe 'polkit' do
       it { is_expected.to contain_service('polkit').with_ensure('running') }
     end
   end
+
+  context 'on Windows' do
+    let(:facts) do
+      FacterDB.get_facts([{:osfamily => 'windows'}]).last
+    end
+
+    let(:scope) { PuppetlabsSpec::PuppetInternals.scope }
+
+    let(:pre_condition) do
+      # Mask `warning` for testing
+      <<~PRE_CONDITION
+      function warning($message) { notify { 'warning_test': message => $message } }
+      PRE_CONDITION
+    end
+
+    it { is_expected.to compile.with_all_deps }
+    it { is_expected.to create_class('polkit') }
+    it { is_expected.to create_notify('warning_test').with_message(/is not supported/) }
+  end
 end

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -23,7 +23,16 @@ describe 'polkit' do
 
   context 'on Windows' do
     let(:facts) do
-      FacterDB.get_facts([{:osfamily => 'windows'}]).last
+      {
+        :os => {
+         "architecture"=>"x64",
+         "family"=>"windows",
+         "hardware"=>"x86_64",
+         "name"=>"windows",
+         "release"=>{"full"=>"2008 R2", "major"=>"2008 R2"},
+         "windows"=>{"system32"=>"C:\\Windows\\system32"}
+        }
+      }
     end
 
     let(:scope) { PuppetlabsSpec::PuppetInternals.scope }


### PR DESCRIPTION
This wraps the defined types in code to make them inert on unsupported
OSs.

The previous code didn't actually do anything on EL6 but the new change
caused it to active break on those systems.

Since we do not have a good idea how widespread usage is, an intert
wrapper seems better than a cascading breaking change given that this is
used in the `simp/simp` module.

SIMP-8228 #comment EL6 backwards compatibility workaround