### PR TITLE
(SIMP-10450) GHA: Update ubuntu-16.04 to latest

### DIFF
--- a/.github/workflows/pr_glci.yml
+++ b/.github/workflows/pr_glci.yml
@@ -63,7 +63,7 @@ jobs:
   # we restrict ourselves to sending data elsewhere.
   glci-syntax:
     name: '.gitlab-ci.yml Syntax'
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-latest
     outputs:
       valid: ${{ steps.validate-glci-file.outputs.valid }}
     steps:
@@ -174,7 +174,7 @@ jobs:
 ###  examine_contexts:
 ###    name: 'Examine Context contents'
 ###    if: always()
-###    runs-on: ubuntu-16.04
+###    runs-on: ubuntu-latest
 ###    needs: [ glci-syntax, contributor-permissions ]
 ###    steps:
 ###      - name: Dump contexts

--- a/.github/workflows/pr_glci_cleanup.yml
+++ b/.github/workflows/pr_glci_cleanup.yml
@@ -93,7 +93,7 @@ jobs:
 ###  examine_contexts:
 ###    name: 'Examine Context contents'
 ###    if: always()
-###    runs-on: ubuntu-16.04
+###    runs-on: ubuntu-latest
 ###    steps:
 ###      - name: Dump contexts
 ###        env:

--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -129,7 +129,7 @@ jobs:
 
 #  dump_contexts:
 #    name: 'Examine Context contents'
-#    runs-on: ubuntu-16.04
+#    runs-on: ubuntu-latest
 #    steps:
 #      - name: Dump contexts
 #        env:

--- a/.github/workflows/release_rpms.yml
+++ b/.github/workflows/release_rpms.yml
@@ -101,16 +101,15 @@ jobs:
             const [owner, repo] = process.env.TARGET_REPO.split('/')
             const tag = process.env.RELEASE_TAG
             const autocreate_release = (process.env.AUTOCREATE_RELEASE == 'yes')
-            var release_id
             const owner_data = { owner: owner, repo: repo }
             const release_data = Object.assign( {tag: tag}, owner_data )
             const create_release_data = Object.assign( {tag_name: tag}, owner_data )
             const tag_data = Object.assign( {ref: `tags/${tag}`}, owner_data )
 
             function id_from_release(data) {
-              console.log( `>> Release for ${owner}/${repo}, tag ${tag}` )
-              console.log( `>>>> release_id: ${data.id}` )
-              return(data.id)
+              console.log( `    >> Release for ${owner}/${repo}, tag ${tag}` )
+              console.log( `    >>>> release_id: ${data.id}` )
+              return data.id
             }
 
             function throw_error_unless_should_autocreate_release(err){
@@ -124,16 +123,19 @@ jobs:
               throw_error_unless_should_autocreate_release(err)
               core.warning(`Can't find release for tag ${tag} and tag exists, auto-creating release`)
 
-              // Must already have a tag
-              github.request( 'GET /repos/{owner}/{repo}/git/matching-refs/{ref}', tag_data ).then (
+              return await github.request( 'GET /repos/{owner}/{repo}/git/matching-refs/{ref}', tag_data ).then (
                 result => {
+                  // Must already have a tag
                   if (result.data.length == 0) { throw `Can't find tag ${tag} in repo ${owner}/${repo}` }
+                  return result
                 }
               ).then(
-                result => {
-                  github.request( 'POST /repos/{owner}/{repo}/releases', create_release_data).then(
+                async result => {
+                  return await github.request( 'POST /repos/{owner}/{repo}/releases', create_release_data).then(
                     result=>{
                       release_id = id_from_release(result.data)
+                      console.log(`    ++ created auto release ${release_id}` )
+                      return release_id
                     },
                     post_err =>{
                       core.error('Error auto-creating release')
@@ -141,21 +143,21 @@ jobs:
                     }
                   )
                 }
-              ).finally(()=>{
-                return(release_id)
-              })
+              )
             }
 
-            github.request('GET /repos/{owner}/{repo}/releases/tags/{tag}', release_data ).then(
-              result => { release_id = id_from_release(result.data) },
-              err => { release_id = autocreate_release_if_appropriate(err) }
-            ).catch( e => { throw e } ).then(
-              result => {
+            await github.request('GET /repos/{owner}/{repo}/releases/tags/{tag}', release_data ).then(
+              async result => { return await id_from_release(result.data) },
+              async err => { return await autocreate_release_if_appropriate(err) }
+            ).then(
+              release_id => {
                 if (!release_id){
                   throw `Could not get release for ${tag} for repo ${owner}:${repo}`
                 }
+                console.log( `    **** release_id: ${release_id}` )
                 core.setOutput('id', release_id)
-              }
+              },
+              err => { throw err }
             )
 
       - name: Checkout code

--- a/.github/workflows/tag_deploy.yml
+++ b/.github/workflows/tag_deploy.yml
@@ -26,6 +26,7 @@
 #
 # * The CHANGLOG text is altered to remove RPM-style date headers, which don't
 #   render well as markdown on the GitHub release pages
+#
 ---
 name: 'Tag: Release to GitHub & Puppet Forge'
 

--- a/.github/workflows/validate_tokens.yml
+++ b/.github/workflows/validate_tokens.yml
@@ -29,7 +29,7 @@ on:
 jobs:
   puppetforge:
     name: 'Puppet Forge token authenticates with API'
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-latest
     env:
       PUPPETFORGE_API_TOKEN: ${{ secrets.PUPPETFORGE_API_TOKEN }}
       FORGE_USER_AGENT: GitHubActions-ForgeReleng-Workflow/0.4.0 (Purpose/forge-ops-for-${{ github.event.repository.name }})
@@ -42,7 +42,7 @@ jobs:
 
   gitlab:
     name: 'GitLab token has scope for developer'
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-latest
     env:
       GITLAB_API_PRIVATE_TOKEN: ${{ secrets.GITLAB_API_PRIVATE_TOKEN }}
       GITLAB_API_URL: ${{ secrets.GITLAB_API_URL }}
@@ -57,7 +57,7 @@ jobs:
 
   github-no-scope:
     name: 'No-scope GitHub token has NO scopes'
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-latest
     env:
       GITHUB_ORG: ${{ github.event.organization.login }}
       NO_SCOPE_GITHUB_TOKEN: ${{secrets.NO_SCOPE_GITHUB_TOKEN}}


### PR DESCRIPTION
GitHub actions' Ubuntu 16.04 environment will be removed on Sept 20,
2021.  This patch migrates all workflow using the `ubuntu-16.04`
environment to `ubuntu-latest`.

The patch enforces a standardized asset baseline using simp/puppetsync,
and may apply other updates to ensure conformity.
[SIMP-10499] #close
[SIMP-10450] #comment Add `release_rpms` to pupmod-simp-polkit

[SIMP-10499]: https://simp-project.atlassian.net/browse/SIMP-10499
[SIMP-10450]: https://simp-project.atlassian.net/browse/SIMP-10450