### PR TITLE
Add clean-state noop acceptance test

### DIFF
--- a/spec/acceptance/suites/default/00_default_spec.rb
+++ b/spec/acceptance/suites/default/00_default_spec.rb
@@ -18,6 +18,26 @@ describe 'polkit' do
     end
 
     hosts.each do |host|
+      # Exercise noop from a clean (uninstalled) state: on a fresh node the Sicura
+      # console previews the module with `puppet apply --noop`, which must not error
+      # even though nothing polkit manages exists yet. Real idempotence is covered
+      # by the applies below. A post-convergence noop check is deliberately omitted:
+      # `puppet apply --noop --detailed-exitcodes` always exits 0, so it could never
+      # fail and would test nothing.
+      context 'in noop mode from a clean state' do
+        # Setup, not an assertion: as before(:context) a failure errors this context
+        # rather than aborting the whole suite under .rspec's --fail-fast. `puppet
+        # resource` exits 0 whether it removes the package or finds it already absent
+        # (no --detailed-exitcodes), so no acceptable_exit_codes override is needed.
+        before(:context) do
+          on(host, 'puppet resource package polkit ensure=absent')
+        end
+
+        it 'applies without errors in noop mode' do
+          apply_manifest_on(host, manifest, catch_failures: true, noop: true)
+        end
+      end
+
       context "on #{host}" do
         it 'applies with no errors' do
           apply_manifest_on(host, manifest)


### PR DESCRIPTION
Adds an acceptance example that applies the module under `puppet apply --noop` from a fresh, uninstalled node — mirroring the preview the Sicura console runs on a clean host — and asserts it completes without error. It reuses the suite's existing default manifest so the check stays representative of the module's real default, and deliberately omits a post-convergence noop check (`--noop --detailed-exitcodes` always exits 0, so it would test nothing).